### PR TITLE
Allow the rake server start to work correctly the first time

### DIFF
--- a/lib/tasks/servers.rake
+++ b/lib/tasks/servers.rake
@@ -9,13 +9,13 @@ namespace :servers do
 
   desc 'Starts development dependencies'
   task start: :environment do
-    system('lando start')
+    # should start automatically for server start
     system('rake servers:initialize')
-    system('rake servers:initialize RAILS_ENV=test')
+    system('rake servers:initialize HANAMI_ENV=test')
   end
 
   desc 'Stop development dependencies'
-  task stop: :environment do
+  task :stop do
     system 'lando stop'
   end
 end


### PR DESCRIPTION
@leefaisonr had issues with the rake tasks running.  I also had issues, but ignored it.

Hanami settings get loaded once, and the settings need lando running to get the database URL.  If it is not running the rest of the `rake servers:start` task will fail.