### PR TITLE
Fixed header title and added plausible dev and staging references for development work

### DIFF
--- a/app/templates/layouts/app.html.erb
+++ b/app/templates/layouts/app.html.erb
@@ -3,11 +3,17 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Orcid princeton</title>
+    <title>ORCID@Princeton</title>
     <%= favicon_tag("favicon-32x32.png") %>
     <%= stylesheet_tag "app" %>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-LN+7fdVzj6u52u30Kp6M/trliBMCMKTyK833zpbD+pXdCLuTusPj697FH4R/5mcr" crossorigin="anonymous">
     <script defer data-domain="orcid.princeton.edu" src="https://plausible.io/js/script.js"></script>
+
+     <% if Hanami.env?(:development) || Hanamin.env?(:staging) %>
+      <%= render 'shared/plausible_dev_staging' %>
+    <% elsif Hanami.env?(:production) %> 
+      <%= render 'shared/plausible' %>
+    <% end %>
   </head>
   <body>
     <div id="lux">

--- a/app/templates/shared/_plausible.html.erb
+++ b/app/templates/shared/_plausible.html.erb
@@ -1,0 +1,1 @@
+<script defer data-domain="orcid.princeton.edu" src="https://plausible.io/js/script.js"></script>

--- a/app/templates/shared/_plausible_dev_staging.html.erb
+++ b/app/templates/shared/_plausible_dev_staging.html.erb
@@ -1,0 +1,1 @@
+<script defer data-domain="orcid-staging.princeton.edu" src="https://plausible.io/js/script.local.js"></script>


### PR DESCRIPTION
This allows the orcid-staging site in Plausible to capture Plausible analytics for local development and activity on the staging server, rather than including these in the production site's analytics.