### PR TITLE
Add Honeybadger error reporting for Entra ID login failures

### DIFF
--- a/app/actions/session/create_entra.rb
+++ b/app/actions/session/create_entra.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'honeybadger'
+
 module OrcidPrinceton
   module Actions
     module Session
@@ -9,16 +11,40 @@ module OrcidPrinceton
 
         def handle(request, response)
           auth_hash = request.env['omniauth.auth']
-          user = user_repo.from_entra_id(auth_hash)
+          if auth_hash.nil?
+            notify_missing_hash(response)
+          else
+            authenticate_entra_user(auth_hash, request, response)
+          end
+        end
 
+        private
+
+        def notify_missing_hash(response)
+          Honeybadger.notify('Entra ID login failed: OmniAuth auth hash is missing')
+          handle_error(response)
+        end
+
+        def authenticate_entra_user(auth_hash, request, response)
+          user = user_repo.from_entra_id(auth_hash)
           if user.nil?
             handle_error(response)
           else
             handle_user(user, request, response)
           end
+        rescue StandardError => e
+          notify_entra_exception(e, auth_hash)
+          handle_error(response)
         end
 
-        private
+        def notify_entra_exception(exception, auth_hash)
+          auth_hash_h = begin
+            auth_hash.to_h
+          rescue StandardError
+            nil
+          end
+          Honeybadger.notify(exception, context: { auth_hash: auth_hash_h })
+        end
 
         def handle_error(response)
           response.flash[:notice] = 'You are not authorized'

--- a/app/repos/user_repo.rb
+++ b/app/repos/user_repo.rb
@@ -61,6 +61,10 @@ module OrcidPrinceton
         result = OrcidPrinceton::Operations::UserFromEntraAttributes.new.call(uid: uid, access_token: access_token)
         if result.instance_of?(Dry::Monads::Result::Success)
           result.value!
+        else
+          require 'honeybadger'
+          Honeybadger.notify("Entra ID login failed: #{result.failure}", context: { uid: uid })
+          nil
         end
       end
 

--- a/spec/actions/session/create_entra_spec.rb
+++ b/spec/actions/session/create_entra_spec.rb
@@ -50,11 +50,52 @@ RSpec.describe OrcidPrinceton::Actions::Session::CreateEntra do
   context 'no auth token' do
     let(:env) { { 'omniauth.auth' => nil, 'warden' => warden_proxy } }
 
-    it 'redirects with an error' do
+    it 'redirects with an error and notifies Honeybadger' do
+      allow(Honeybadger).to receive(:notify)
       response = subject.call(env)
       expect(response).to be_redirect
       expect(response.location).to eq Hanami.app.router.path(:root)
       expect(response.flash.next[:notice]).to eq('You are not authorized')
+      expect(Honeybadger).to have_received(:notify).with('Entra ID login failed: OmniAuth auth hash is missing')
+    end
+  end
+
+  context 'when user registration/retrieval fails with a Failure monad' do
+    before do
+      allow(Honeybadger).to receive(:notify)
+      # Cause the operation to fail
+      mock_operation = instance_double(OrcidPrinceton::Operations::UserFromEntraAttributes)
+      allow(mock_operation).to receive(:call)
+        .and_return(Dry::Monads::Result::Failure.new('LDAP lookup failed'))
+      allow(OrcidPrinceton::Operations::UserFromEntraAttributes).to receive(:new).and_return(mock_operation)
+    end
+
+    it 'redirects with an error and notifies Honeybadger of the specific failure' do
+      response = subject.call(env)
+      expect(response).to be_redirect
+      expect(response.location).to eq Hanami.app.router.path(:root)
+      expect(response.flash.next[:notice]).to eq('You are not authorized')
+      expect(Honeybadger).to have_received(:notify).with('Entra ID login failed: LDAP lookup failed',
+                                                         context: { uid: 'test456' })
+    end
+  end
+
+  context 'when an exception occurs' do
+    before do
+      allow(Honeybadger).to receive(:notify)
+      allow(subject.user_repo).to receive(:from_entra_id)
+        .and_raise(StandardError.new('Unexpected DB Connection Failure'))
+    end
+
+    it 'redirects with an error, catches the exception and logs to Honeybadger with context' do
+      response = subject.call(env)
+      expect(response).to be_redirect
+      expect(response.location).to eq Hanami.app.router.path(:root)
+      expect(response.flash.next[:notice]).to eq('You are not authorized')
+      expect(Honeybadger).to have_received(:notify).with(
+        an_instance_of(StandardError),
+        context: hash_including(auth_hash: an_instance_of(Hash))
+      )
     end
   end
 end


### PR DESCRIPTION
Advances #330 with the following:

- Notify Honeybadger when the OmniAuth authentication hash is missing in the CreateEntra action.
- Catch unexpected StandardErrors during Entra ID authentication and report them with context containing safe hash serialization of the OmniAuth hash.
- Report registration or retrieval failures returning Failure monads (e.g., LDAP failures) in UserRepo#from_entra_id, including UID context.
- Add and expand unit tests in spec/actions/session/create_entra_spec.rb to cover all Honeybadger notification pathways.