### PR TITLE
Add build, watch, and Prettier formatting scripts to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,12 @@
   "name": "orcid_princeton",
   "private": true,
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "build": "node config/assets.js --path=app --dest=public/assets",
+    "watch": "node config/assets.js --path=app --dest=public/assets --watch",
+    "format": "prettier --write \"app/assets/js/**/*.js\" \"config/**/*.js\"",
+    "format:check": "prettier --check \"app/assets/js/**/*.js\" \"config/**/*.js\""
+  },
   "dependencies": {
     "@popperjs/core": "^2.11.8",
     "esbuild": "^0.28.0",


### PR DESCRIPTION
- Add "build" and "watch" scripts in package.json to execute config/assets.js for asset bundling.
- Add "format" and "format:check" scripts in package.json to format and verify JavaScript code style in app assets and config files using Prettier.