### PR TITLE
Reorganize npm packages jrgriffiniii

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,12 @@
   "name": "orcid_princeton",
   "private": true,
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "build": "node config/assets.js --path=app --dest=public/assets",
+    "watch": "node config/assets.js --path=app --dest=public/assets --watch",
+    "format": "prettier --write \"app/assets/js/**/*.js\" \"config/**/*.js\"",
+    "format:check": "prettier --check \"app/assets/js/**/*.js\" \"config/**/*.js\""
+  },
   "dependencies": {
     "@popperjs/core": "^2.11.8",
     "esbuild": "^0.28.0",

--- a/package.json
+++ b/package.json
@@ -10,13 +10,14 @@
   },
   "dependencies": {
     "@popperjs/core": "^2.11.8",
-    "esbuild": "^0.28.0",
-    "esbuild-plugin-vue3": "^0.5.0",
-    "hanami-assets": "^3.0.0",
     "lux-design-system": "^7.0.0",
-    "prettier": "^3.6.0",
     "vue": "^3.5.17",
     "vue3-runtime-template": "^1.0.2"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "esbuild": "^0.28.0",
+    "esbuild-plugin-vue3": "^0.5.0",
+    "hanami-assets": "^3.0.0",
+    "prettier": "^3.6.0"
+  }
 }


### PR DESCRIPTION
Reorganizes runtime dependencies and devDependencies in package.json by moving development, formatting, and asset compilation dependencies (esbuild, esbuild-plugin-vue3, hanami-assets, and prettier) from "dependencies" to "devDependencies". This cleanly separates build-time tools from application runtime dependencies, allowing for leaner and more optimized production environment builds.