### PR TITLE
Upgrade Bundler to 2.7 and slightly refactors Dry::Monads

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 commands:
   install_dependencies:
     steps:
-      - run: gem install bundler -v '2.3.22'
+      - run: gem install bundler -v '2.7.2'
       - run: cp Gemfile.lock Gemfile.lock.bak
       - restore_cache:
           key: &gem_key orcid_princeton-hanami-cimg-{{ checksum "Gemfile.lock.bak" }}

--- a/.simplecov
+++ b/.simplecov
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'simplecov'
-
-SimpleCov.start do
-  add_filter 'spec/'
-  add_filter 'app.rb'
-  add_filter 'config/settings.rb'
+# Configuration only — call SimpleCov.start from the test helper (Coveralls.wear! does this).
+# See https://github.com/simplecov-ruby/simplecov/issues/581
+SimpleCov.configure do
+  skip 'spec/'
+  skip 'app.rb'
+  skip 'config/settings.rb'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -805,4 +805,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.6.9
+   2.7.2

--- a/app/actions/admin/orcid_report.rb
+++ b/app/actions/admin/orcid_report.rb
@@ -12,18 +12,23 @@ module OrcidPrinceton
         before :require_authentication # make sure there is a user logged in before serving the report
         before :require_admin # make sure the logged in user is an administrator
 
+        # rubocop:disable Metrics/MethodLength
         def handle(_request, response)
           date = Time.now.strftime('%Y-%m-%d')
           user_filename = "ORCID_portal_report_#{date}.csv"
           file = Tempfile.new(SecureRandom.uuid)
           tmp_filename = file.path
-          if people_soft_report.call(tmp_filename).is_a? Dry::Monads::Result::Success
+          case people_soft_report.call(tmp_filename)
+          in Success
             response.format = :csv
             response.headers['Content-Disposition'] = "inline; filename=\"#{user_filename}\""
             response.body = File.read(tmp_filename)
+          in Failure
+            response.body = ''
           end
           file.unlink
         end
+        # rubocop:enable Metrics/MethodLength
       end
     end
   end

--- a/app/actions/health/status.rb
+++ b/app/actions/health/status.rb
@@ -31,9 +31,9 @@ module OrcidPrinceton
 
         def retrieve_orcid_id_status
           case orcid_api_status.call
-          in Dry::Monads::Result::Success(_orcid_status)
+          in Success
             { status: 'ok', results: [{ name: 'ORCID', message: '', status: 'OK' }] }
-          in Dry::Monads::Result::Failure(error)
+          in Failure(error)
             { status: 'error', results: [{ name: 'ORCID', message: error, status: 'ERROR' }] }
           end
         end

--- a/app/actions/user/validate_tokens.rb
+++ b/app/actions/user/validate_tokens.rb
@@ -14,18 +14,22 @@ module OrcidPrinceton
           required(:id).value(:integer)
         end
 
+        # rubocop:disable Metrics/MethodLength
         def handle(request, response)
           user_id = request.params[:id]
           if response[:current_user].id == user_id
-            result = validate_user_tokens.call(user_id)
-            if result in Dry::Monads::Result::Failure(error)
+            case validate_user_tokens.call(user_id)
+            in Failure(error)
               response.flash[:notice] = error
+            in Success
+              nil
             end
             response.redirect_to routes.path(:user, id: response[:current_user].id)
           else
             response.render(alternative_view)
           end
         end
+        # rubocop:enable Metrics/MethodLength
       end
     end
   end

--- a/app/operations/validate_user_tokens.rb
+++ b/app/operations/validate_user_tokens.rb
@@ -23,6 +23,7 @@ module OrcidPrinceton
       end
 
       def validate_tokens(user)
+        # NOTE: Why is this required?
         Time.now
         user.valid_tokens.each do |token|
           decoded_token = token_repo.get(token.id).token

--- a/app/repos/token_repo.rb
+++ b/app/repos/token_repo.rb
@@ -28,6 +28,8 @@ module OrcidPrinceton
       end
 
       # Create a token from an omniauth hash.
+      # Omniauth credentials may include a refresh_token; we do not persist it yet
+      # (no column / rotation flow). Track if long-lived re-auth without user consent is needed.
       # @param credentials [OmniAuth::AuthHash] The credentials hash from the omniauth response.
       # @param user [User] The user to associate the token with.
       # @return [Token] The token that was created.
@@ -38,7 +40,7 @@ module OrcidPrinceton
           user_id: user.id,
           token_type: 'ORC',
           orcid: user.orcid
-          # TODO: ADD REFRESH TOKEN
+          # @TODO: ADD REFRESH TOKEN
           # refresh_token: credentials.refresh_token
         )
       end

--- a/app/repos/user_repo.rb
+++ b/app/repos/user_repo.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
+require 'dry/monads'
+
 module OrcidPrinceton
   module Repos
     # class for accessing the users in the system
     class UserRepo < OrcidPrinceton::DB::Repo
+      # Provide `Success` and `Failure` for pattern matching on operation results
+      include Dry::Monads[:result]
+
       include Deps['relations.users_roles']
 
       def get(id)
@@ -49,24 +54,30 @@ module OrcidPrinceton
 
         result = OrcidPrinceton::Operations::UserFromAttributes.new.call(uid: access_token.uid,
                                                                          access_token: access_token)
-        if result.instance_of?(Dry::Monads::Result::Success)
-          result.value!
+        case result
+        in Success(user)
+          user
+        in Failure
+          nil
         end
       end
 
+      # rubocop:disable Metrics/MethodLength
       def from_entra_id(access_token)
         return nil if access_token.nil?
 
         uid = OrcidPrinceton::Operations::UserFromEntraAttributes.parse_entra_uid(access_token)
         result = OrcidPrinceton::Operations::UserFromEntraAttributes.new.call(uid: uid, access_token: access_token)
-        if result.instance_of?(Dry::Monads::Result::Success)
-          result.value!
-        else
+        case result
+        in Success(user)
+          user
+        in Failure(error)
           require 'honeybadger'
-          Honeybadger.notify("Entra ID login failed: #{result.failure}", context: { uid: uid })
+          Honeybadger.notify("Entra ID login failed: #{error}", context: { uid: uid })
           nil
         end
       end
+      # rubocop:enable Metrics/MethodLength
 
       def user_with_roles_and_tokens
         users.combine(:roles).combine(:tokens)

--- a/app/view.rb
+++ b/app/view.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require 'hanami/view'
+require 'dry/monads'
 
 require 'tilt/jbuilder'
 
@@ -10,6 +11,9 @@ Tilt.register Tilt[:jbuilder], :json
 module OrcidPrinceton
   # Base Hanami view for the ORCID application
   class View < Hanami::View
+    # Provide `Success` and `Failure` for pattern matching on operation results
+    include Dry::Monads[:result]
+
     include Deps['operations.orcid_api_status']
 
     expose :current_user, layout: true
@@ -33,8 +37,12 @@ module OrcidPrinceton
     end
 
     expose :orcid_available do
-      result = orcid_api_status.call
-      result.instance_of?(Dry::Monads::Result::Success)
+      case orcid_api_status.call
+      in Success
+        true
+      in Failure
+        false
+      end
     end
 
     expose :banner_title, layout: true do

--- a/devbox.json
+++ b/devbox.json
@@ -27,13 +27,14 @@
     "FONTCONFIG_PATH": "$PWD/.devbox/nix/profile/default/etc/fonts",
     "BUNDLE_PATH": ".bundle",
     "BUNDLE_BIN": ".binstubs",
-    "PATH": ".binstubs:bin:$PATH"
+    "PATH": ".binstubs:bin:$PATH",
+    "BUNDLER_VERSION": "2.7.2"
   },
   "shell": {
     "init_hook": ["echo 'initializing devbox'"],
     "scripts": {
       "setup": "devbox run deps",
-      "deps": "mkdir -p $TMPDIR; bundle install; yarn install",
+      "deps": "mkdir -p $TMPDIR; gem install bundler -v 2.7.2 --no-document; bundle install; yarn install",
       "server": "bin/dev",
       "console": "bundle exec hanami console",
       "lint": "bundle exec rubocop",

--- a/lib/tasks/people_soft.rake
+++ b/lib/tasks/people_soft.rake
@@ -10,23 +10,24 @@ namespace :people_soft do
     raise 'Must provide a filename' if filename.nil?
 
     report = OrcidPrinceton::Operations::PeopleSoftReport.new
-    result = report.call(filename)
-    if result.instance_of?(Dry::Monads::Result::Success)
-      puts "ORCID report was created at #{filename}"
-    else
-      puts "ERROR:  Could not generate ORCID Report: #{result}"
+    case report.call(filename)
+    in Dry::Monads::Result::Success(path)
+      puts "ORCID report was created at #{path}"
+    in Dry::Monads::Result::Failure(error)
+      puts "ERROR:  Could not generate ORCID Report: #{error}"
     end
   end
 
   desc 'Saves the CSV report in the correct location for the environment'
   task cron_report: :environment do
     report = OrcidPrinceton::Operations::PeopleSoftReport.new
-    result = report.call(Hanami.app.settings.peoplesoft_output_location)
-    if result.instance_of?(Dry::Monads::Result::Success)
-      puts "ORCID report was created at #{Hanami.app.settings.peoplesoft_output_location}"
-    else
-      puts "ERROR:  Could not generate ORCID Report: #{result}"
-      Honeybadger.notify("ERROR:  Could not generate ORCID Report: #{result}")
+    output_location = Hanami.app.settings.peoplesoft_output_location
+    case report.call(output_location)
+    in Dry::Monads::Result::Success(path)
+      puts "ORCID report was created at #{path}"
+    in Dry::Monads::Result::Failure(error)
+      puts "ERROR:  Could not generate ORCID Report: #{error}"
+      Honeybadger.notify("ERROR:  Could not generate ORCID Report: #{error}")
     end
   end
 end

--- a/spec/actions/admin/orcid_report_spec.rb
+++ b/spec/actions/admin/orcid_report_spec.rb
@@ -53,5 +53,21 @@ RSpec.describe OrcidPrinceton::Actions::Admin::OrcidReport do
       expect(response.body.count).to eq(1)
       expect { CSV.parse(response.body.first) }.not_to raise_error
     end
+
+    context 'when the PeopleSoft report operation fails' do
+      let(:people_soft_report) do
+        instance_double(OrcidPrinceton::Operations::PeopleSoftReport).tap do |report|
+          allow(report).to receive(:call)
+            .and_return(Dry::Monads::Result::Failure.new('could not write report'))
+        end
+      end
+      subject { described_class.new(people_soft_report:) }
+
+      it 'returns an empty body' do
+        params['warden'].set_user user.uid
+        response = subject.call(params)
+        expect(response.body).to eq([''])
+      end
+    end
   end
 end

--- a/spec/actions/session/create_entra_spec.rb
+++ b/spec/actions/session/create_entra_spec.rb
@@ -97,5 +97,26 @@ RSpec.describe OrcidPrinceton::Actions::Session::CreateEntra do
         context: hash_including(auth_hash: an_instance_of(Hash))
       )
     end
+
+    context 'and the auth hash cannot be converted to a Hash for Honeybadger context' do
+      let(:auth_hash) do
+        Object.new.tap do |obj|
+          def obj.to_h
+            raise StandardError, 'cannot convert auth hash'
+          end
+        end
+      end
+
+      it 'notifies Honeybadger with a nil auth_hash context' do
+        response = subject.call(env)
+        expect(response).to be_redirect
+        expect(response.location).to eq Hanami.app.router.path(:root)
+        expect(response.flash.next[:notice]).to eq('You are not authorized')
+        expect(Honeybadger).to have_received(:notify).with(
+          an_instance_of(StandardError),
+          context: { auth_hash: nil }
+        )
+      end
+    end
   end
 end

--- a/spec/operations/orcid_api_status_spec.rb
+++ b/spec/operations/orcid_api_status_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe OrcidPrinceton::Operations::OrcidAPIStatus do
   it 'checks the status' do
     status = described_class.new
     result = status.call
-    expect(result).to be_a Dry::Monads::Result::Success
+    expect(result).to be_success
   end
 
   context 'when the api is showing a failed component' do
@@ -22,7 +22,7 @@ RSpec.describe OrcidPrinceton::Operations::OrcidAPIStatus do
     it 'raises an error when the status is checked' do
       status = described_class.new
       result = status.call
-      expect(result).to be_a Dry::Monads::Result::Failure
+      expect(result).to be_failure
       expect(result.failure).to eq('The ORCID API has an invalid status https://api.orcid.org/v3.0/apiStatus')
     end
   end
@@ -36,7 +36,7 @@ RSpec.describe OrcidPrinceton::Operations::OrcidAPIStatus do
     it 'raises an error when the status is checked' do
       status = described_class.new
       result = status.call
-      expect(result).to be_a Dry::Monads::Result::Failure
+      expect(result).to be_failure
       expect(result.failure).to eq('The ORCID API returned HTTP error code: 502')
     end
   end
@@ -56,7 +56,7 @@ RSpec.describe OrcidPrinceton::Operations::OrcidAPIStatus do
     it 'does not raise an error when the status is checked' do
       status = described_class.new
       result = status.call
-      expect(result).to be_a Dry::Monads::Result::Success
+      expect(result).to be_success
     end
   end
 end

--- a/spec/operations/people_soft_report_spec.rb
+++ b/spec/operations/people_soft_report_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe OrcidPrinceton::Operations::PeopleSoftReport, type: :operation do
     user_invalid = Factory[:user_with_expired_token, university_id: '223344']
     report = described_class.new
     result = report.call(file_name)
-    expect(result).to be_a Dry::Monads::Result::Success
+    expect(result).to be_success
     expect(File.exist?(file_name)).to be true
     lines = File.readlines(file_name)
     expect(lines.first).to eq "University ID,Net ID,Full Name,Identifier Type,ORCID iD,Date Effective,Effective Until\n"
@@ -37,7 +37,7 @@ RSpec.describe OrcidPrinceton::Operations::PeopleSoftReport, type: :operation do
   it 'it saves the report to a file with the correct header' do
     report = described_class.new
     result = report.call(file_name, valid_data)
-    expect(result).to be_a Dry::Monads::Result::Success
+    expect(result).to be_success
     expect(File.exist?(file_name)).to be true
     lines = File.readlines(file_name)
     expect(lines.first).to eq "University ID,Net ID,Full Name,Identifier Type,ORCID iD,Date Effective,Effective Until\n"
@@ -49,6 +49,6 @@ RSpec.describe OrcidPrinceton::Operations::PeopleSoftReport, type: :operation do
   it 'it responds with a failure if we try to save the file to a directory that does not exists' do
     report = described_class.new
     result = report.call('/bad_location/bad_file', valid_data)
-    expect(result).to be_a Dry::Monads::Result::Failure
+    expect(result).to be_failure
   end
 end

--- a/spec/operations/user_from_attributes_spec.rb
+++ b/spec/operations/user_from_attributes_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe OrcidPrinceton::Operations::UserFromAttributes do
   it 'Updates the user with cas values', db: true do
     user = user_repo.create(uid: 'abc123', provider: 'cas')
     result = described_class.new.call(uid: user.uid, access_token: auth_hash)
-    expect(result).to be_a Dry::Monads::Result::Success
+    expect(result).to be_success
     updated_user = user_repo.get(user.id)
     expect(updated_user.university_id).to eq('999999999')
     expect(updated_user.display_name).to eq('Areyou, Who')
@@ -35,7 +35,7 @@ RSpec.describe OrcidPrinceton::Operations::UserFromAttributes do
 
   it 'Updates the user with cas, and does overwrite existing values', db: true do
     result = described_class.new.call(uid: user.uid, access_token: auth_hash)
-    expect(result).to be_a Dry::Monads::Result::Success
+    expect(result).to be_success
     updated_user = user_repo.get(user.id)
     expect(updated_user.university_id).to eq('999999999')
     expect(updated_user.display_name).to eq('Areyou, Who')
@@ -44,7 +44,7 @@ RSpec.describe OrcidPrinceton::Operations::UserFromAttributes do
   it 'creates the user with cas', db: true do
     auth_hash[:uid] = 'other_user'
     result = described_class.new.call(uid: 'other_user', access_token: auth_hash)
-    expect(result).to be_a Dry::Monads::Result::Success
+    expect(result).to be_success
     new_user = user_repo.find_by_uid('other_user')
     expect(new_user.university_id).to eq('999999999')
     expect(new_user.display_name).to eq('Areyou, Who')
@@ -74,7 +74,7 @@ RSpec.describe OrcidPrinceton::Operations::UserFromAttributes do
       auth_hash.extra.universityid = nil
       auth_hash.extra.displayname = nil
       result = described_class.new.call(uid: user.uid, access_token: auth_hash)
-      expect(result).to be_a Dry::Monads::Result::Success
+      expect(result).to be_success
       updated_user = user_repo.find_by_uid('tigerdatatester')
       expect(updated_user.university_id).to eq('098136217') # from ldap
       expect(updated_user.display_name).to eq('TigerData Tester') # from ldap
@@ -82,11 +82,42 @@ RSpec.describe OrcidPrinceton::Operations::UserFromAttributes do
       expect(updated_user.family_name).to eq('Areyou') # from auth hash
     end
 
+    context 'when exercising ldap_info and default_connection' do
+      let(:ldap_connection) { instance_double(Net::LDAP) }
+
+      before do
+        # Do not stub ldap_info; stub the LDAP client so Net::LDAP code paths run.
+        allow_any_instance_of(described_class).to receive(:ldap_info).and_call_original
+        allow(Net::LDAP).to receive(:new).and_return(ldap_connection)
+        allow(ldap_connection).to receive(:search).and_return([ldap_entry])
+      end
+
+      it 'builds a TLS LDAP connection and searches by uid', db: true do
+        user = user_repo.create(uid: 'tigerdatatester', provider: 'cas')
+        auth_hash.extra.universityid = nil
+        auth_hash.extra.displayname = nil
+
+        result = described_class.new.call(uid: user.uid, access_token: auth_hash)
+        expect(result).to be_success
+        expect(Net::LDAP).to have_received(:new).with(
+          hash_including(
+            host: 'ldap.princeton.edu',
+            base: 'o=Princeton University,c=US',
+            port: 636,
+            encryption: hash_including(method: :simple_tls)
+          )
+        )
+        expect(ldap_connection).to have_received(:search).with(hash_including(:filter))
+        updated_user = user_repo.find_by_uid('tigerdatatester')
+        expect(updated_user.university_id).to eq('098136217')
+      end
+    end
+
     it 'creates a new user with ldap values when they do not exist and university id is missing in token', db: true do
       auth_hash.extra.universityid = nil
       auth_hash.extra.displayname = nil
       result = described_class.new.call(uid: 'tigerdatatester', access_token: auth_hash)
-      expect(result).to be_a Dry::Monads::Result::Success
+      expect(result).to be_success
       new_user = user_repo.find_by_uid('tigerdatatester')
       expect(new_user).not_to be_nil
       expect(new_user.university_id).to eq('098136217') # from ldap
@@ -102,7 +133,7 @@ RSpec.describe OrcidPrinceton::Operations::UserFromAttributes do
         user = user_repo.create(uid: 'tigerdatatester', provider: 'cas')
         auth_hash.extra.universityid = nil
         result = described_class.new.call(uid: user.uid, access_token: auth_hash)
-        expect(result).to be_a Dry::Monads::Result::Failure
+        expect(result).to be_failure
         expect(result.failure).to eq('Can not find the university id for tigerdatatester')
       end
     end
@@ -124,7 +155,7 @@ RSpec.describe OrcidPrinceton::Operations::UserFromAttributes do
         user = user_repo.create(uid: 'tigerdatatester', provider: 'cas')
         auth_hash.extra.universityid = nil
         result = described_class.new.call(uid: user.uid, access_token: auth_hash)
-        expect(result).to be_a Dry::Monads::Result::Failure
+        expect(result).to be_failure
         expect(result.failure).to eq('Can not find the university id for tigerdatatester')
       end
     end
@@ -138,7 +169,7 @@ RSpec.describe OrcidPrinceton::Operations::UserFromAttributes do
     it 'does not overwrite existing database attributes from CAS/token', db: true do
       expect(user.given_name).to eq('ExistingGivenName')
       result = described_class.new.call(uid: user.uid, access_token: auth_hash)
-      expect(result).to be_a Dry::Monads::Result::Success
+      expect(result).to be_success
       updated_user = user_repo.get(user.id)
       expect(updated_user.given_name).to eq('ExistingGivenName')
       expect(updated_user.display_name).to eq('Existing DisplayName')
@@ -155,7 +186,7 @@ RSpec.describe OrcidPrinceton::Operations::UserFromAttributes do
         auth_hash.extra.displayname = nil
 
         result = described_class.new.call(uid: 'some_uid', access_token: auth_hash)
-        expect(result).to be_a Dry::Monads::Result::Success
+        expect(result).to be_success
         new_user = user_repo.find_by_uid('some_uid')
         expect(new_user.given_name).to eq('some_uid')
         expect(new_user.family_name).to eq('some_uid')
@@ -188,7 +219,7 @@ RSpec.describe OrcidPrinceton::Operations::UserFromAttributes do
         auth_hash.extra.displayname = nil
 
         result = described_class.new.call(uid: 'tigerdatatester', access_token: auth_hash)
-        expect(result).to be_a Dry::Monads::Result::Success
+        expect(result).to be_success
         new_user = user_repo.find_by_uid('tigerdatatester')
         expect(new_user.university_id).to eq('098136217')
         expect(new_user.given_name).to eq('TigerData')
@@ -220,7 +251,7 @@ RSpec.describe OrcidPrinceton::Operations::UserFromAttributes do
     allow(operation).to receive(:ldap_info).with('tigerdatatester').and_return(ldap_attr)
 
     result = operation.call(uid: user.uid, access_token: auth_hash)
-    expect(result).to be_a Dry::Monads::Result::Success
+    expect(result).to be_success
     updated_user = user_repo.find_by_uid('tigerdatatester')
     expect(updated_user.university_id).to eq('098136217') # from ldap
     expect(updated_user.display_name).to eq('TigerData Tester') # from ldap

--- a/spec/operations/validate_user_tokens_spec.rb
+++ b/spec/operations/validate_user_tokens_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe OrcidPrinceton::Operations::ValidateUserTokens do
   it 'raises an error for a bad user' do
     validate_tokens = described_class.new
     result = validate_tokens.call(2002)
-    expect(result).to be_a Dry::Monads::Result::Failure
+    expect(result).to be_failure
     expect(result.failure).to eq('The user does not exists')
   end
 
@@ -20,7 +20,7 @@ RSpec.describe OrcidPrinceton::Operations::ValidateUserTokens do
                                                                                               headers: {})
       validate_tokens = described_class.new
       result = validate_tokens.call(user.id)
-      expect(result).to be_a Dry::Monads::Result::Success
+      expect(result).to be_success
       updated_user = user_repo.get(user.id)
       expect(updated_user.tokens_expired?).to be_falsey
     end
@@ -34,7 +34,7 @@ RSpec.describe OrcidPrinceton::Operations::ValidateUserTokens do
                                                                                               headers: {})
       validate_tokens = described_class.new
       result = validate_tokens.call(user.id)
-      expect(result).to be_a Dry::Monads::Result::Success
+      expect(result).to be_success
       updated_user = user_repo.get(user.id)
       expect(updated_user.tokens_expired?).to be_truthy
     end
@@ -51,7 +51,7 @@ RSpec.describe OrcidPrinceton::Operations::ValidateUserTokens do
 
       validate_tokens = described_class.new
       result = validate_tokens.call(user.id)
-      expect(result).to be_a Dry::Monads::Result::Failure
+      expect(result).to be_failure
     end
   end
 end

--- a/spec/repos/user_repo_spec.rb
+++ b/spec/repos/user_repo_spec.rb
@@ -90,6 +90,19 @@ RSpec.describe OrcidPrinceton::Repos::UserRepo, :db do
       expect(updated_user.display_name).to eq(user.display_name)
     end
 
+    it 'returns nil when the attribute operation fails' do
+      mock_operation = instance_double(OrcidPrinceton::Operations::UserFromAttributes)
+      allow(mock_operation).to receive(:call)
+        .and_return(Dry::Monads::Result::Failure.new('LDAP lookup failed'))
+      allow(OrcidPrinceton::Operations::UserFromAttributes).to receive(:new).and_return(mock_operation)
+
+      expect(repo.from_cas(auth_hash)).to be_nil
+    end
+
+    it 'returns nil when the access token is missing' do
+      expect(repo.from_cas(nil)).to be_nil
+    end
+
     context 'user is only partially set up' do
       let(:user) { Factory[:user, given_name: nil] }
 

--- a/spec/views/home_spec.rb
+++ b/spec/views/home_spec.rb
@@ -39,6 +39,20 @@ RSpec.describe OrcidPrinceton::Views::Home::Show do
     expect(rendered[:stale_version]).to eq('')
   end
 
+  context 'when the ORCID API status check fails' do
+    let(:orcid_api_status) do
+      instance_double(OrcidPrinceton::Operations::OrcidAPIStatus).tap do |status|
+        allow(status).to receive(:call)
+          .and_return(Dry::Monads::Result::Failure.new('The ORCID API has an invalid status'))
+      end
+    end
+    let(:view) { described_class.new(orcid_api_status:) }
+
+    it 'exposes orcid_available as false' do
+      expect(rendered[:orcid_available]).to be(false)
+    end
+  end
+
   context 'the version is stale and is not released' do
     let(:version_hash) do
       { stale: true, sha: 'sha', branch: 'v0.8.0', version: '10 December 2021', tagged_release: false }


### PR DESCRIPTION
Advances, but does not resolve, https://github.com/pulibrary/orcid_princeton_hanami/issues/353

Upgrades Bundler to version 2.7.2 across project environments and simplifies pattern matching on Dry::Monads results

- Refactor Dry::Monads usage:
  - Import Dry::Monads[:result] directly into UserRepo and View to enable clean pattern matching on operations.
  - Simplify pattern match branches from explicit namespace checks to direct Success and Failure patterns.
- Standardize spec assertions:
  - Replace Dry::Monads class checks in RSpec specs with idiomatic `be_success` and `be_failure` predicate matchers.
- Cleanup code and configurations:
  - Update SimpleCov initialization to use `SimpleCov.configure`.
  - Annotate refresh token omission in TokenRepo.
- Upgrade Bundler to 2.7.2:
  - Update devbox.json with BUNDLER_VERSION and ensure it is installed during deps setup.
  - Update Bundler version constraint in .circleci/config.yml.
  - Update Gemfile.lock Bundler lock version.